### PR TITLE
Adding Info

### DIFF
--- a/chooser.php
+++ b/chooser.php
@@ -129,7 +129,7 @@ error_reporting(E_ALL);
 set_time_limit(60);
 
 // ZabbixAPI Connection
-ZabbixAPI::debugEnabled(TRUE);
+ZabbixAPI::debugEnabled(TRUE); // SET TO FALSE TO NOT SHOW SOME INFORMATION IN PLAIN TEXT. SET TO TRUE TO DEBBUG ERRORS
 ZabbixAPI::login($z_server,$z_user,$z_pass)
 	or die('Unable to login: '.print_r(ZabbixAPI::getLastError(),true));
 //fetch graph data host


### PR DESCRIPTION
Adding info about the line of "ZabbixAPI::debugEnabled(TRUE)". In production, set to FALSE to avoid show information that don't need to appear.